### PR TITLE
feat: Hide "is displaying over other apps" notification in English and French

### DIFF
--- a/app/src/main/java/com/iboalali/sysnotifsnooze/NotificationListener.java
+++ b/app/src/main/java/com/iboalali/sysnotifsnooze/NotificationListener.java
@@ -76,8 +76,9 @@ public class NotificationListener extends NotificationListenerService {
 
                     String nc = getString(R.string.notification_content_singular);
                     String ncp = getString(R.string.notification_content_plural);
+                    String ncd = getString(R.string.notification_content_display_over);
 
-                    if (key.contains(nc) || key.contains(ncp)) {
+                    if (key.contains(nc) || key.contains(ncp) || key.contains(ncd)) {
                         NotificationListener.this.snoozeNotification(sbn.getKey(), 10000000000000L);
                         Log.d(TAG, sbn.getPackageName() + ": " + key + ", snoozed");
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2,4 +2,5 @@
 <resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
     <string name="notification_content_singular">s\'exécute en arrière-plan</string>
     <string name="notification_content_plural"> applications s\'exécutent en arrière-plan</string>
+    <string name="notification_content_display_over">s\'affiche sur autres applis</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="title_activity_main_settings" translatable="false">Hide Running in the Background Notification</string>
     <string name="notification_content_singular">is running in the background</string>
     <string name="notification_content_plural">apps are running in the background</string>
+    <string name="notification_content_display_over">is displaying over other apps</string>
     <string name="notification_intent_key" translatable="false">android.title</string>
     <string name="hidden_success" translatable="false">Successfully Hidden</string>
     <string name="granted" translatable="false">Granted</string>


### PR DESCRIPTION
This hides the "is displaying over other apps" notification. This is only for English, I'm not sure how you got all the other translations besides manually changing the language.