### PR TITLE
Improve notification detection

### DIFF
--- a/app/src/main/java/com/iboalali/sysnotifsnooze/NotificationListener.java
+++ b/app/src/main/java/com/iboalali/sysnotifsnooze/NotificationListener.java
@@ -1,5 +1,6 @@
 package com.iboalali.sysnotifsnooze;
 
+import android.app.Notification;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -15,6 +16,16 @@ import android.util.Log;
 public class NotificationListener extends NotificationListenerService {
     private static final String TAG = "NotificationListener";
     private NotificationListenerBroadcastReceiver notificationListenerBroadcastReceiver;
+
+    /**
+     * This is set on the notification shown by the activity manager about all apps
+     * running in the background.  It indicates that the notification should be shown
+     * only if any of the given apps do not already have a {@link Notification#FLAG_FOREGROUND_SERVICE}
+     * notification currently visible to the user.  This is a string array of all
+     * package names of the apps.
+     * @hide
+     */
+    public static final String EXTRA_FOREGROUND_APPS = "android.foregroundApps";
 
     @Override
     public void onCreate() {
@@ -33,62 +44,40 @@ public class NotificationListener extends NotificationListenerService {
         }
     }
 
+    private void checkAndSnoozeNotification(StatusBarNotification sbn)
+    {
+        if (sbn.getPackageName().equals("android") && sbn.getNotification().extras.containsKey(EXTRA_FOREGROUND_APPS)) {
+            String key = sbn.getNotification().extras.getString(Notification.EXTRA_TITLE);
+            if (key == null) return;
+
+            snoozeNotification(sbn.getKey(), 10000000000000L);
+            //Long.MAX_VALUE = 9223372036854775807 = 292.5 million years -> not working
+            //10000000000000 = 317.09792 years -> working
+
+            Log.d(TAG, sbn.getPackageName() + ": " + key + ", snoozed");
+        }
+    }
+
     @Override
     public void onNotificationPosted(StatusBarNotification sbn) {
         if (sbn == null)
             return;
 
-        if (sbn.getPackageName().equals("android")) {
-            Log.d(TAG, sbn.getPackageName() + ": " + sbn.getNotification().extras.getString(getString(R.string.notification_intent_key), ""));
-
-            String key = sbn.getNotification().extras.getString(getString(R.string.notification_intent_key));
-            if (key == null) return;
-
-            String nc = getString(R.string.notification_content_singular);
-            String ncp = getString(R.string.notification_content_plural);
-
-            if (key.contains(nc) || key.contains(ncp)) {
-                NotificationListener.this.snoozeNotification(sbn.getKey(), 10000000000000L);
-                Log.d(TAG, sbn.getPackageName() + ": " + key + ", snoozed");
-
-            }
-            //Long.MAX_VALUE = 9223372036854775807 = 292.5 million years -> not working
-            //10000000000000 = 317.09792 years -> working
-
-        }
+        checkAndSnoozeNotification(sbn);
     }
 
-    class NotificationListenerBroadcastReceiver extends BroadcastReceiver{
-    private static final String TAG = "NL Broadcast Receiver";
+    class NotificationListenerBroadcastReceiver extends BroadcastReceiver {
+        private static final String TAG = "NL Broadcast Receiver";
 
         @Override
         public void onReceive(Context context, Intent intent) {
             Log.d(TAG, "Received Broadcast");
 
-            if(intent.getStringExtra("command").equals("hide")){
-                for(StatusBarNotification sbn: NotificationListener.this.getActiveNotifications()){
-
-                    if (sbn.getPackageName().equals("android")) {
-                        Log.d(TAG, "List: " + sbn.getPackageName() + ": " + sbn.getNotification().extras.getString(getString(R.string.notification_intent_key), ""));
-
-                        String key = sbn.getNotification().extras.getString(getString(R.string.notification_intent_key));
-                        if (key == null) return;
-
-                        String nc = getString(R.string.notification_content_singular);
-                        String ncp = getString(R.string.notification_content_plural);
-
-                        if (key.contains(nc) || key.contains(ncp)) {
-                            NotificationListener.this.snoozeNotification(sbn.getKey(), 10000000000000L);
-                            Log.d(TAG, sbn.getPackageName() + ": " + key + ", snoozed");
-
-                        }
-                    }
+            if (intent.getStringExtra("command").equals("hide")) {
+                for (StatusBarNotification sbn : NotificationListener.this.getActiveNotifications()) {
+                    checkAndSnoozeNotification(sbn);
                 }
             }
         }
     }
-
-
-
-
 }

--- a/app/src/main/res/values-af/strings.xml
+++ b/app/src/main/res/values-af/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">በጀርባ ውስጥ እያሄደ ነው</string>
-    <string name="notification_content_plural">መተግበሪያዎች በጀርባ ውስጥ እያሄዱ ነው</string>
-</resources>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">loop tans op die agtergrond</string>
-    <string name="notification_content_plural">programme loop tans op die agtergrond</string>
-</resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">في الخلفية</string>
-    <string name="notification_content_plural">تطبيق في الخلفية</string>
-</resources>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">arxa fonda işləyir</string>
-    <string name="notification_content_plural">tətbiq arxa fonda işləyir</string>
-</resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">се изпълнява на заден план</string>
-    <string name="notification_content_plural">приложения работят на заден план</string>
-</resources>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">অ্যাপ চালু আছে</string>
-    <string name="notification_content_plural">টি অ্যাপ চালু আছে</string>
-</resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">s\'està executant en segon pla</string>
-    <string name="notification_content_plural">aplicacions s\'estan executant en segon pla</string>
-</resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">běží na pozadí</string>
-    <string name="notification_content_plural">běží na pozadí</string>
-</resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">kører i baggrunden</string>
-    <string name="notification_content_plural">apps kører i baggrunden</string>
-</resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Verstecke die \"im Hintergrund ausgeführt\" Benachrichtigung</string>
+    <string name="Allow">Erlauben</string>
+    <string name="OK">OK</string>
+    <string name="string_settings_large_donation">eine Große Spende</string>
+    <string name="string_settings_small_donation">eine Kleine Spende</string>
+    <string name="string_settings_notification_access_permission">Benachrichtigungszugriff</string>
+    <string name="granted">Erlaubt</string>
+    <string name="string_settings_follow_me">Folge mir</string>
+    <string name="string_settings_permission">Berechtigung</string>
+    <string name="string_settings_support_me_with">Unterstütze mich mit …</string>
+    <string name="title_activity_main_settings">Verstecke die Im Hintergrund ausgeführt Benachrichtigung</string>
+    <string name="not_granted">Nicht Erlaubt</string>
+    <string name="permission_request_msg">\"Um die lästige \"im Hintergrung ausgefüht\" Benachrichtigung zu verstecken, muss du diese App das zugriff auf deine Benachrichtigungen erlauben.\n\nDrücke OK, und in der nächsten Seite, lege den Schalter um und drücke auf \"Zulassen\"</string>
+    <string name="permission_request_title">Erlaubnis zum Zugreifen auf deine Benachrichtigungen</string>
+</resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">wird im Hintergrund ausgeführt</string>
-    <string name="notification_content_plural">Apps werden im Hintergrund ausgeführt</string>
-</resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">εκτελείται στο παρασκήνιο</string>
-    <string name="notification_content_plural">εφαρμογές εκτελούνται στο παρασκήνιο</string>
-</resources>

--- a/app/src/main/res/values-en-rAU/strings.xml
+++ b/app/src/main/res/values-en-rAU/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">is running in the background</string>
-    <string name="notification_content_plural">apps are running in the background</string>
-</resources>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">is running in the background</string>
-    <string name="notification_content_plural">apps are running in the background</string>
-</resources>

--- a/app/src/main/res/values-en-rIN/strings.xml
+++ b/app/src/main/res/values-en-rIN/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">is running in the background</string>
-    <string name="notification_content_plural">apps are running in the background</string>
-</resources>

--- a/app/src/main/res/values-es-rUS/strings.xml
+++ b/app/src/main/res/values-es-rUS/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">se está ejecutando en segundo plano</string>
-    <string name="notification_content_plural">apps se están ejecutando en segundo plano</string>
-</resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">se está ejecutando en segundo plano</string>
-    <string name="notification_content_plural">aplicaciones se están ejecutando en segundo plano</string>
-</resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">käitatakse taustal</string>
-    <string name="notification_content_plural">rakendust käitatakse taustal</string>
-</resources>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">exekutatzen ari da atzeko planoan</string>
-    <string name="notification_content_plural">exekutatzen ari dira atzeko planoan</string>
-</resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">در پس‌زمینه درحال اجرا شدن است</string>
-    <string name="notification_content_plural">برنامه در پس‌زمینه درحال اجرا شدن هستند</string>
-</resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">on käynnissä taustalla</string>
-    <string name="notification_content_plural">sovellusta on käynnissä taustalla</string>
-</resources>

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">fonctionne en arrière-plan</string>
-    <string name="notification_content_plural"> applications fonctionnent en arrière-plan</string>
-</resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">s\'exécute en arrière-plan</string>
-    <string name="notification_content_plural"> applications s\'exécutent en arrière-plan</string>
-</resources>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">Estase executando en segundo plano a aplicación</string>
-    <string name="notification_content_plural">Estanse executando en segundo plano</string>
-</resources>

--- a/app/src/main/res/values-gu/strings.xml
+++ b/app/src/main/res/values-gu/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">પૃષ્ઠભૂમિમાં ચાલી રહી છે</string>
-    <string name="notification_content_plural">ઍપ્લિકેશન પૃષ્ઠભૂમિમાં ચાલી રહી છે</string>
-</resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">बैकग्राउंड में चल रहा है</string>
-    <string name="notification_content_plural">ऐप्लिकेशन बैकग्राउंड में चल रहे हैं</string>
-</resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">izvodi se u pozadini</string>
-    <string name="notification_content_plural">Aplikacije koje se izvode u pozadini</string>
-</resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">a háttérben fut</string>
-    <string name="notification_content_plural">alkalmazás még fut a háttérben</string>
-</resources>

--- a/app/src/main/res/values-hy/strings.xml
+++ b/app/src/main/res/values-hy/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">ն աշխատում է ֆոնային ռեժիմում</string>
-    <string name="notification_content_plural">հավելված աշխատում են ֆոնում</string>
-</resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">sedang berjalan di latar belakang</string>
-    <string name="notification_content_plural">aplikasi sedang berjalan di latar belakang</string>
-</resources>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">keyrir í bakgrunni</string>
-    <string name="notification_content_plural">forrit keyra í bakgrunni</string>
-</resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">è in esecuzione in background</string>
-    <string name="notification_content_plural">app sono in esecuzione in background</string>
-</resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">פועלת ברקע</string>
-    <string name="notification_content_plural">אפליקציות פועלות ברקע</string>
-</resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">がバックグラウンドで実行中です</string>
-    <string name="notification_content_plural">個のアプリがバックグラウンドで実行中です</string>
-</resources>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">გაშვებულია ფონურ რეჟიმში</string>
-    <string name="notification_content_plural">ფონურ რეჟიმში გაშვებულია</string>
-</resources>

--- a/app/src/main/res/values-kk/strings.xml
+++ b/app/src/main/res/values-kk/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">фонда жұмыс істеп тұр</string>
-    <string name="notification_content_plural">қолданба фонда жұмыс істеп тұр</string>
-</resources>

--- a/app/src/main/res/values-km/strings.xml
+++ b/app/src/main/res/values-km/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">កំពុងដំណើរការនៅផ្ទៃខាងក្រោយ</string>
-    <string name="notification_content_plural">កំពុងដំណើរការនៅផ្ទៃខាងក្រោយ</string>
-</resources>

--- a/app/src/main/res/values-kn/strings.xml
+++ b/app/src/main/res/values-kn/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">ರನ್ ಆಗುತ್ತಿದೆ</string>
-    <string name="notification_content_plural">ಅಪ್ಲಿಕೇಶನ್‌ಗಳು ಹಿನ್ನೆಲೆಯಲ್ಲಿ ರನ್ ಆಗುತ್ತಿವೆ</string>
-</resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">앱이 백그라운드에서 실행 중</string>
-    <string name="notification_content_plural">개의 앱이 백그라운드에서 실행 중</string>
-</resources>

--- a/app/src/main/res/values-ky/strings.xml
+++ b/app/src/main/res/values-ky/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">колдонмосу фондо иштеп жатат</string>
-    <string name="notification_content_plural">колдонмо фондо иштөөдө</string>
-</resources>

--- a/app/src/main/res/values-lo/strings.xml
+++ b/app/src/main/res/values-lo/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">ກຳລັງເຮັດວຽກໃນພື້ນຫຼັງ</string>
-    <string name="notification_content_plural">ແອັບກຳລັງເຮັດວຽກໃນພື້ນຫຼັງ</string>
-</resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">veikia fone</string>
-    <string name="notification_content_plural">veikia fone</string>
-</resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">darbojas fonā</string>
-    <string name="notification_content_plural">lietotnes darbojas fonā</string>
-</resources>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">се извршува во заднина</string>
-    <string name="notification_content_plural">апликации се извршуваат во заднина</string>
-</resources>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">പശ്ചാത്തലത്തിൽ റൺ ചെയ്യുന്നു</string>
-    <string name="notification_content_plural">ആപ്പുകൾ പശ്ചാത്തലത്തിൽ റൺ ചെയ്യുന്നു</string>
-</resources>

--- a/app/src/main/res/values-mn/strings.xml
+++ b/app/src/main/res/values-mn/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">ард ажиллаж байна</string>
-    <string name="notification_content_plural">апп цаана ажиллаж байна</string>
-</resources>

--- a/app/src/main/res/values-mr/strings.xml
+++ b/app/src/main/res/values-mr/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">बॅकग्राउंडमध्‍ये चालू आहे</string>
-    <string name="notification_content_plural">अॅप्‍स बॅकग्राउंडमध्‍ये चालू आहेत</string>
-</resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">sedang berjalan di latar belakang</string>
-    <string name="notification_content_plural">apl sedang berjalan di latar belakang</string>
-</resources>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">သည် နောက်ခံတွင် ပွင့်နေပါသည်</string>
-    <string name="notification_content_plural">ခုသည် နောက်ခံတွင် ပွင့်နေပါသည်</string>
-</resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">kjører i bakgrunnen</string>
-    <string name="notification_content_plural">apper kjører i bakgrunnen</string>
-</resources>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">पृष्ठभूमिमा चल्दैछ</string>
-    <string name="notification_content_plural">अनुप्रयोगहरू पृष्ठभूमिमा चल्दैछन्</string>
-</resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">is op de achtergrond actief</string>
-    <string name="notification_content_plural">apps worden uitgevoerd op de achtergrond</string>
-</resources>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">ਐਪ ਬੈਕਗ੍ਰਾਊਂਡ ਵਿੱਚ ਚੱਲ ਰਹੀ ਹੈ</string>
-    <string name="notification_content_plural">ਐਪਾਂ ਬੈਕਗ੍ਰਾਊਂਡ ਵਿੱਚ ਚੱਲ ਰਹੀਆਂ ਹਨ</string>
-</resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">działa w tle</string>
-    <string name="notification_content_plural">działają w tle</string>
-</resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">está sendo executado em segundo plano</string>
-    <string name="notification_content_plural">apps estão sendo executados em segundo plano</string>
-</resources>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">está a ser executada em segundo plano</string>
-    <string name="notification_content_plural">aplicações estão a ser executadas em segundo plano</string>
-</resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">está sendo executado em segundo plano</string>
-    <string name="notification_content_plural">apps estão sendo executados em segundo plano</string>
-</resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">rulează în fundal</string>
-    <string name="notification_content_plural">aplicații rulează în fundal</string>
-</resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">в фоновом режиме</string>
-    <string name="notification_content_plural">работает в фоновом режиме</string>
-</resources>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">පසුබිමින් ධාවනය වේ</string>
-    <string name="notification_content_plural">ක් පසුබිමින් ධාවනය වේ</string>
-</resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">je spustená na pozadí</string>
-    <string name="notification_content_plural">je spustených na pozadí</string>
-</resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">se izvaja v ozadju</string>
-    <string name="notification_content_plural">se izvaja v ozadju</string>
-</resources>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">po ekzekutohet në sfond</string>
-    <string name="notification_content_plural">aplikacione po ekzekutohen në sfond</string>
-</resources>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">ради у позадини</string>
-    <string name="notification_content_plural">су покренуте у позадини</string>
-</resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">körs i bakgrunden</string>
-    <string name="notification_content_plural">appar körs i bakgrunden</string>
-</resources>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">inatumika chinichini</string>
-    <string name="notification_content_plural">zinatumika chinichini</string>
-</resources>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">பின்னணியில் இயங்குகிறது</string>
-    <string name="notification_content_plural">பயன்பாடுகள் பின்னணியில் இயங்குகின்றன</string>
-</resources>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">నేపథ్యంలో అమలు అవుతోంది</string>
-    <string name="notification_content_plural">ఆప్‌లు నేపథ్యంలో అమలు అవుతున్నాయి</string>
-</resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">กำลังทำงานในเบื้องหลัง</string>
-    <string name="notification_content_plural">กำลังทำงานในเบื้องหลัง</string>
-</resources>

--- a/app/src/main/res/values-tl/strings.xml
+++ b/app/src/main/res/values-tl/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">sa background</string>
-    <string name="notification_content_plural">app ang tumatakbo sa background</string>
-</resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">arka planda çalışıyor</string>
-    <string name="notification_content_plural">uygulama arka planda çalışıyor</string>
-</resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">працює у фоновому режимі</string>
-    <string name="notification_content_plural">Додатки, які працюють у фоновому режимі</string>
-</resources>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">پس منظر میں چل رہی ہے</string>
-    <string name="notification_content_plural">ایپس پس منظر میں چل رہی ہیں</string>
-</resources>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">orqa fonda ishlayapti</string>
-    <string name="notification_content_plural">ta ilova fonda ishlamoqda</string>
-</resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">đang chạy ẩn</string>
-    <string name="notification_content_plural">ứng dụng đang chạy trong nền</string>
-</resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">正在后台运行</string>
-    <string name="notification_content_plural">个应用正在后台运行</string>
-</resources>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">正在背景執行</string>
-    <string name="notification_content_plural">個應用程式正在背景中執行</string>
-</resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">正在背景執行</string>
-    <string name="notification_content_plural">個應用程式正在背景執行</string>
-</resources>

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"     tools:ignore="MissingTranslation" >
-    <string name="notification_content_singular">iyasebenza ngemuva</string>
-    <string name="notification_content_plural">izinhlelo zokusebenza ziyasebenza ngemuva</string>
-</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,30 +1,26 @@
 <resources>
-    <string name="app_name" translatable="false">Hide \"running in the background\" Notification</string>
+    <string name="app_name">Hide \"running in the background\" Notification</string>
     <string name="service_name" translatable="false">@string/app_name</string>
-    <string name="permission_request_msg" translatable="false">For this app to remove the annoying \"running in the background\" Notification, you have to allow this app to access your notifications.\n\nPress OK, and in the next screen, switch the permission for this app ON and then press \"Allow\"</string>
-    <string name="permission_request_title" translatable="false">Permission to Access Notifications</string>
-    <string name="Allow" translatable="false">Allow</string>
-    <string name="OK" translatable="false">OK</string>
-    <string name="title_activity_main_settings" translatable="false">Hide Running in the Background Notification</string>
-    <string name="notification_content_singular">is running in the background</string>
-    <string name="notification_content_plural">apps are running in the background</string>
-    <string name="notification_intent_key" translatable="false">android.title</string>
-    <string name="hidden_success" translatable="false">Successfully Hidden</string>
-    <string name="granted" translatable="false">Granted</string>
-    <string name="not_granted" translatable="false">Not Granted</string>
-    <string name="string_settings_small_donation" translatable="false">a Small Donation</string>
-    <string name="string_settings_large_donation" translatable="false">a Large Donation</string>
-    <string name="string_settings_follow_me" translatable="false">Follow me</string>
-    <string name="string_settings_notification_access_permission" translatable="false">Notification Access Permission</string>
-    <string name="string_settings_permission" translatable="false">Permission</string>
-    <string name="string_settings_support_me_with" translatable="false">Support me with …</string>
+    <string name="permission_request_msg">For this app to remove the annoying \"running in the background\" Notification, you have to allow this app to access your notifications.\n\nPress OK, and in the next screen, switch the permission for this app ON and then press \"Allow\"</string>
+    <string name="permission_request_title">Permission to Access Notifications</string>
+    <string name="Allow">Allow</string>
+    <string name="OK">OK</string>
+    <string name="title_activity_main_settings">Hide Running in the Background Notification</string>
+    <string name="granted">Granted</string>
+    <string name="not_granted">Not Granted</string>
+    <string name="string_settings_small_donation">a Small Donation</string>
+    <string name="string_settings_large_donation">a Large Donation</string>
+    <string name="string_settings_follow_me">Follow me</string>
+    <string name="string_settings_notification_access_permission">Notification Access Permission</string>
+    <string name="string_settings_permission">Permission</string>
+    <string name="string_settings_support_me_with">Support me with …</string>
     <string name="string_filter_intent" translatable="false">com.iboalali.sysnotifsnooze.NOTIFICATION_LISTENER_SERVICE_INTENT</string>
-    <string name="string_settings_hide_app_icon_from_launcher" translatable="false">Hide app icon from launcher</string>
-    <string name="string_settings_settings" translatable="false">Settings</string>
-    <string name="string_hide_icon_alert_dialog_title" translatable="false">Hide the app icon from launcher?</string>
-    <string name="string_hide_icon_alert_dialog_msg" translatable="false">This switch will hide the app icon from launcher.\n\nCaution!\nYou have to uninstall and install this app from the Play Store again to open it</string>
+    <string name="string_settings_hide_app_icon_from_launcher">Hide app icon from launcher</string>
+    <string name="string_settings_settings">Settings</string>
+    <string name="string_hide_icon_alert_dialog_title">Hide the app icon from launcher?</string>
+    <string name="string_hide_icon_alert_dialog_msg">This switch will hide the app icon from launcher.\n\nCaution!\nYou have to uninstall and install this app from the Play Store again to open it</string>
     <string name="string_sharedPreferences_isIconHidden" translatable="false">isIconHidden</string>
-    <string name="string_yes" translatable="false">Yes</string>
-    <string name="string_no" translatable="false">No</string>
+    <string name="string_yes">Yes</string>
+    <string name="string_no">No</string>
     <string name="string_sharedPref_granted" translatable="false">granted?</string>
 </resources>


### PR DESCRIPTION
The "running in the background" notification has an
"android.foregroundApps" extra that can be used to tell it apart from
other android system notifications, we can use that instead of matching
the notification title.

https://github.com/aosp-mirror/platform_frameworks_base/blob/master/services/core/java/com/android/server/am/ActiveServices.java#L887
